### PR TITLE
Re-enable replace-megaparsec, replace-attoparsec

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -8648,7 +8648,6 @@ expected-test-failures:
     - rando # https://github.com/commercialhaskell/stackage/issues/4249
     - rank1dynamic
     - readline # 1.0.3.0
-    - replace-megaparsec # https://github.com/jamesdbrock/replace-megaparsec/issues/38
     - rescue
     - roc-id # 0.1.0.0 negative quickcheck resize
     - rose-trees


### PR DESCRIPTION
Undo a35ae2a

There was a bug in GHC v9.4.3 which was fixed in v9.4.4

See https://github.com/jamesdbrock/replace-megaparsec/issues/38

Checklist:
- [x] Meaningful commit message, eg `add my-cool-package` (please don't mention `build-constraints.yml`)
- [x] At least 30 minutes have passed since uploading to Hackage
- [x] If applicable, required system libraries are added to [02-apt-get-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/02-apt-get-install.sh) or [03-custom-install.sh](https://github.com/commercialhaskell/stackage/blob/master/docker/03-custom-install.sh)
- [x] (optional) Package is compatible with the latest version of all dependencies (Run `cabal update && cabal outdated`)
- [x] (optional) Package have been verified to work with the latest nightly snapshot, e.g by running the [verify-package script](https://github.com/commercialhaskell/stackage/blob/master/verify-package)

The script runs virtually the following commands in a clean directory:

      stack unpack $package-$version # `-$version` is optional
      cd $package-$version
      rm -f stack.yaml && stack init --resolver nightly --ignore-subdirs
      stack build --resolver nightly --haddock --test --bench --no-run-benchmarks
